### PR TITLE
Switch from bundle to bundler in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,6 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    bundle (0.0.1)
-      bundler
     diff-lcs (1.2.1)
     mime-types (2.0)
     rake (10.0.3)
@@ -25,7 +23,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundle
+  bundler
   rake
   rspec (~> 2.13.0)
   wordpressto!

--- a/wordpressto.gemspec
+++ b/wordpressto.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', "~> 2.13.0")
-  s.add_development_dependency "bundle"
+  s.add_development_dependency "bundler"
 end


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo and updates the Gemfile.lock